### PR TITLE
Geolocation 모바일 디바이스 이슈 수정 및 재시도 로직 추가

### DIFF
--- a/app/components/common/Dialog.tsx
+++ b/app/components/common/Dialog.tsx
@@ -21,7 +21,7 @@ function Dialog(
   return (
     <dialog
       ref={ref}
-      className="open:animate-show-dialog open:backdrop:animate-show-backdrop bottom-0 top-auto mx-0 my-0 max-h-[80%] w-full max-w-none transform rounded-t-xl bg-dialog-background backdrop:bg-dialog-backdrop md:inset-y-0 md:mx-auto md:my-auto md:w-96 md:rounded-b-xl"
+      className="bottom-0 top-auto mx-0 my-0 max-h-[80%] w-full max-w-none transform rounded-t-xl bg-dialog-background will-change-transform backdrop:bg-dialog-backdrop open:animate-show-dialog open:backdrop:animate-show-backdrop md:inset-y-0 md:mx-auto md:my-auto md:w-96 md:rounded-b-xl"
       onClick={handleCloseDialog}
       role="dialog"
       aria-modal="true"

--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -25,28 +25,24 @@ function DirectionWrap() {
     setIsLoading(true);
     openDialog();
 
-    try {
-      const {
-        route: { traoptimal },
-      } = await getRoute(start, goal);
-      setDirections(traoptimal[0]);
-    } catch (error) {
-      const geolocationError = error as GeolocationPositionError;
-      console.error(`길 찾기 실패: ${error}`);
-      if (geolocationError.code === 1) {
-        alert('위치 권한이 거부되었습니다.');
-      } else if (geolocationError.code === 2) {
-        alert('위치 정보를 사용할 수 없습니다.');
-      } else if (geolocationError.code === 3) {
-        alert('위치 정보를 가져오는 데 시간이 초과되었습니다.');
-      }
-    } finally {
-      setIsLoading(false);
-    }
+    const {
+      route: { traoptimal },
+    } = await getRoute(start, goal);
+
+    setDirections(traoptimal[0]);
+    setIsLoading(false);
   };
 
   const handleError = (error: GeolocationPositionError) => {
-    alert(`위치 조회 실패: ${error.code} / ${error.message}`);
+    if (error.code === 1) {
+      alert(
+        '위치 조회 실패: 위치 권한이 거부되었습니다. 설정에서 권한을 허용해주세요.',
+      );
+    } else if (error.code === 2) {
+      alert('위치 조회 실패: 위치 정보를 사용할 수 없습니다.');
+    } else if (error.code === 3) {
+      alert('위치 조회 실패: 위치 정보를 가져오는 데 시간이 초과되었습니다.');
+    }
   };
 
   const handleClick = () => {

--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -18,14 +18,22 @@ function DirectionWrap() {
   const [directions, setDirections] = useState<Direction | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleSuccess = async (position: GeolocationPosition) => {
+  const requestCurrentLoaction = () => {
+    navigator.geolocation.getCurrentPosition(
+      findRouteFromCurrentLocation,
+      handleError,
+    );
+  };
+
+  const findRouteFromCurrentLocation = async (
+    position: GeolocationPosition,
+  ) => {
     const latitude = position.coords.latitude;
     const longitude = position.coords.longitude;
     const start = `${longitude},${latitude}`;
     const goal = sessionStorage.getItem('destination') || '';
 
     setIsLoading(true);
-    openDialog();
 
     const {
       route: { traoptimal },
@@ -47,13 +55,14 @@ function DirectionWrap() {
     }
   };
 
-  const findRouteFromCurrentLocation = () => {
+  const handleFindRouteClick = () => {
     if (!('geolocation' in navigator)) {
       alert('브라우저가 위치 조회를 지원하지 않습니다.');
       return;
     }
 
-    navigator.geolocation.getCurrentPosition(handleSuccess, handleError);
+    openDialog();
+    requestCurrentLoaction();
   };
 
   return (
@@ -61,7 +70,7 @@ function DirectionWrap() {
       <button
         type="button"
         className="my-2 flex h-11 w-full items-center justify-center gap-1 rounded-lg bg-emerald-600 font-semibold"
-        onClick={findRouteFromCurrentLocation}
+        onClick={handleFindRouteClick}
         aria-label="현재 위치에서 목적지까지 길 찾기"
       >
         <IconNavigation className="h-4 w-4" />
@@ -93,8 +102,9 @@ function DirectionWrap() {
                 type="button"
                 className="my-2 flex h-11 w-full items-center justify-center gap-1 rounded-lg bg-emerald-600 font-semibold"
                 aria-label="길 찾기 다시 시도"
+                onClick={requestCurrentLoaction}
               >
-                <span className="text-white">재시도</span>
+                <span className="text-white">경로 재탐색</span>
                 <IconRetry className="h-4 w-4" />
               </button>
             </div>

--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -45,7 +45,7 @@ function DirectionWrap() {
     }
   };
 
-  const handleClick = () => {
+  const findRouteFromCurrentLocation = () => {
     if (!('geolocation' in navigator)) {
       alert('브라우저가 위치 조회를 지원하지 않습니다.');
       return;
@@ -59,7 +59,7 @@ function DirectionWrap() {
       <button
         type="button"
         className="my-2 flex h-11 w-full items-center justify-center gap-1 rounded-lg bg-emerald-600 font-semibold"
-        onClick={handleClick}
+        onClick={findRouteFromCurrentLocation}
         aria-label="현재 위치에서 목적지까지 길 찾기"
       >
         <IconNavigation className="h-4 w-4" />

--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -10,6 +10,8 @@ import IconNavigation from '@/app/components/icons/IconNavigation';
 import DirectionDescriptionSkeleton from '@/app/components/direction/DirectionDescriptionSkeleton';
 import DirectionMapSkeleton from '@/app/components/Map/DirectionMapSkeleton';
 import DirectionDescription from './DirectionDescription';
+import IconRetry from '@/app/components/icons/IconRetry';
+import IconInfo from '@/app/components/icons/IconInfo';
 
 function DirectionWrap() {
   const { dialogRef, openDialog, closeDialog } = useDialog();
@@ -78,9 +80,24 @@ function DirectionWrap() {
               <DirectionMap path={directions.path} />
             </>
           ) : (
-            <p className="h-[28.5rem] w-full">
-              길 찾기에 실패했습니다. 다시 시도해주세요.
-            </p>
+            <div className="flex h-[28.5rem] w-full flex-col items-center justify-center gap-3">
+              <div className="flex flex-1 flex-col items-center justify-center gap-6">
+                <IconInfo className="h-10 w-10" />
+                <p className="text-center text-white">
+                  길 찾기에 실패했습니다.
+                  <br />
+                  다시 시도해주세요.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="my-2 flex h-11 w-full items-center justify-center gap-1 rounded-lg bg-emerald-600 font-semibold"
+                aria-label="길 찾기 다시 시도"
+              >
+                <span className="text-white">재시도</span>
+                <IconRetry className="h-4 w-4" />
+              </button>
+            </div>
           )}
         </div>
       </Dialog>

--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -17,6 +17,7 @@ function DirectionWrap() {
   const { dialogRef, openDialog, closeDialog } = useDialog();
   const [directions, setDirections] = useState<Direction | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
 
   const requestCurrentLoaction = () => {
     navigator.geolocation.getCurrentPosition(
@@ -33,13 +34,18 @@ function DirectionWrap() {
     const start = `${longitude},${latitude}`;
     const goal = sessionStorage.getItem('destination') || '';
 
+    setIsError(false);
     setIsLoading(true);
 
-    const {
-      route: { traoptimal },
-    } = await getRoute(start, goal);
+    const { data, isError } = await getRoute(start, goal);
 
-    setDirections(traoptimal[0]);
+    if (isError || !data) {
+      setIsError(true);
+      setDirections(null);
+    } else {
+      setDirections(data);
+    }
+
     setIsLoading(false);
   };
 
@@ -83,12 +89,7 @@ function DirectionWrap() {
               <DirectionDescriptionSkeleton />
               <DirectionMapSkeleton />
             </>
-          ) : directions ? (
-            <>
-              <DirectionDescription summary={directions.summary} />
-              <DirectionMap path={directions.path} />
-            </>
-          ) : (
+          ) : isError ? (
             <div className="flex h-[28.5rem] w-full flex-col items-center justify-center gap-3">
               <div className="flex flex-1 flex-col items-center justify-center gap-6">
                 <IconInfo className="h-10 w-10" />
@@ -108,6 +109,13 @@ function DirectionWrap() {
                 <IconRetry className="h-4 w-4" />
               </button>
             </div>
+          ) : (
+            directions && (
+              <>
+                <DirectionDescription summary={directions.summary} />
+                <DirectionMap path={directions.path} />
+              </>
+            )
           )}
         </div>
       </Dialog>

--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -49,30 +49,13 @@ function DirectionWrap() {
     alert(`위치 조회 실패: ${error.code} / ${error.message}`);
   };
 
-  const handleClick = async () => {
+  const handleClick = () => {
     if (!('geolocation' in navigator)) {
       alert('브라우저가 위치 조회를 지원하지 않습니다.');
       return;
     }
 
-    try {
-      const permissionsStatus = await navigator.permissions.query({
-        name: 'geolocation',
-      });
-
-      if (permissionsStatus.state === 'denied') {
-        alert('위치 권한이 차단되었습니다. 위치 권한 설정을 허용해주세요.');
-        return;
-      }
-
-      if (permissionsStatus.state === 'prompt') {
-        alert('현재 위치를 사용하시려면 권한을 허용해주세요.');
-      }
-
-      navigator.geolocation.getCurrentPosition(handleSuccess, handleError);
-    } catch (error) {
-      alert(`위치 권한 확인 중 오류가 발생했습니다: ${error}`);
-    }
+    navigator.geolocation.getCurrentPosition(handleSuccess, handleError);
   };
 
   return (

--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -75,12 +75,13 @@ function DirectionWrap() {
     <>
       <button
         type="button"
-        className="my-2 flex h-11 w-full items-center justify-center gap-1 rounded-lg bg-emerald-600 font-semibold"
+        className="loading my-2 flex h-11 w-full items-center justify-center gap-1 rounded-lg bg-emerald-600 font-semibold"
         onClick={handleFindRouteClick}
         aria-label="현재 위치에서 목적지까지 길 찾기"
+        disabled={isLoading}
       >
         <IconNavigation className="h-4 w-4" />
-        길찾기
+        <span>길 찾기</span>
       </button>
       <Dialog ref={dialogRef} title="길 찾기 모달" handleClose={closeDialog}>
         <div aria-live="polite">

--- a/app/components/icons/IconInfo.tsx
+++ b/app/components/icons/IconInfo.tsx
@@ -1,0 +1,21 @@
+function IconInfo({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className || ''}
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="12" fill="#D1D5D9" />
+      <path
+        d="M12.6486 14.2041H11.3514L11.0676 7.33463L11 5H13L12.9324 7.33463L12.6486 14.2041ZM13 18H11.027V15.615H13V18Z"
+        fill="#000000"
+      />
+    </svg>
+  );
+}
+
+export default IconInfo;

--- a/app/components/icons/IconRetry.tsx
+++ b/app/components/icons/IconRetry.tsx
@@ -1,0 +1,29 @@
+function IconRetry({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className || ''}
+      version="1.0"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24.000000pt"
+      height="24.000000pt"
+      viewBox="0 0 24.000000 24.000000"
+      preserveAspectRatio="xMidYMid meet"
+      aria-hidden="true"
+    >
+      <g
+        transform="translate(0.000000,24.000000) scale(0.100000,-0.100000)"
+        fill="#ffffff"
+        stroke="none"
+      >
+        <path
+          d="M51 206 c-47 -26 -63 -84 -36 -135 15 -31 65 -57 90 -47 20 7 10 26
+-14 26 -25 0 -61 42 -61 71 0 50 63 84 109 59 25 -13 36 -42 14 -38 -29 5 -24
+-17 9 -42 l31 -23 24 29 c28 35 29 48 3 41 -13 -3 -21 1 -25 14 -16 50 -92 74
+-144 45z"
+        />
+      </g>
+    </svg>
+  );
+}
+
+export default IconRetry;

--- a/app/globals.css
+++ b/app/globals.css
@@ -32,4 +32,8 @@ body {
   .skeleton-rounded {
     @apply relative overflow-hidden rounded-md before:absolute before:h-full before:w-[200%] before:animate-wave before:bg-gradient-to-r before:from-skeleton-start before:to-skeleton-end;
   }
+
+  .loading {
+    @apply disabled:before:bg-disabaled-background relative disabled:before:absolute disabled:before:inset-0 disabled:before:h-full disabled:before:w-full disabled:after:absolute disabled:after:z-[1] disabled:after:h-5 disabled:after:w-5 disabled:after:animate-spin disabled:after:rounded-full disabled:after:border-2 disabled:after:border-white disabled:after:border-b-transparent disabled:after:border-t-transparent;
+  }
 }

--- a/app/lib/getRoute.ts
+++ b/app/lib/getRoute.ts
@@ -8,11 +8,21 @@ type RouteResponse = {
 };
 
 const getRoute = async (start: string, goal: string) => {
-  const res = await axios.get<RouteResponse>('directions', {
-    params: { start, goal },
-  });
+  try {
+    const res = await axios.get<RouteResponse>('directions', {
+      params: { start, goal },
+    });
 
-  return res.data;
+    return {
+      isError: false,
+      data: res.data.route.traoptimal[0] || null,
+    };
+  } catch (error) {
+    return {
+      isError: true,
+      data: null,
+    };
+  }
 };
 
 export default getRoute;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,6 +20,7 @@ export default {
         'skeleton-end': '#414345',
         'dialog-backdrop': 'rgba(0,0,0,0.5)',
         'dialog-background': '#1E201E',
+        'disabaled-background': 'rgba(0,0,0,0.7)',
       },
       fontSize: {
         '4xl': ['2.5rem', { lineHeight: '3rem' }], // 40px / 48px


### PR DESCRIPTION
## #️⃣연관된 이슈

#43

## 📝작업 내용

- [x] 에러 처리를 Geolocation의 에러 핸들러에서만 수행하도록 통합
- [x] 로직 분리 및 이름 직관적으로 수정
- [x] 길 찾기 에러 UI 추가
- [x] 길 찾기 재시도 로직 추가
- [x] 길 찾기 버튼 disabled 상태 추가 (AOS dialog가 늦게 열리는 이슈 고려해 로딩 애니메이션 추가)

### 스크린샷
#### 길 찾기 에러 발생
##### 모바일 (~768px)
![image](https://github.com/user-attachments/assets/6f8e2896-6281-415f-9b5b-f5365f5666f7)
##### 태블릿 & PC(768px~)
![image](https://github.com/user-attachments/assets/81ce6217-0fa9-472f-a6fc-0e07cacc95b1)
#### 길 찾기 버튼 - Disabled(Loading) 애니메이션
![맛길-Chrome-2025-02-25-13-30-23-_online-video-cutter com_](https://github.com/user-attachments/assets/13862565-d3d8-4a0c-8fc5-ff15f36b7a4a)

