### PR TITLE
fix: 모바일 디바이스에서 권한 거부 및 묻기 설정 시 Dialog가 먼저 열리는 이슈 수정

### DIFF
--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -34,6 +34,7 @@ function DirectionWrap() {
     const start = `${longitude},${latitude}`;
     const goal = sessionStorage.getItem('destination') || '';
 
+    openDialog();
     setIsError(false);
     setIsLoading(true);
 
@@ -67,7 +68,6 @@ function DirectionWrap() {
       return;
     }
 
-    openDialog();
     requestCurrentLoaction();
   };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #45 

## 📝작업 내용
- 위치 권한 거부 상태나 위치 권한 설정 alert에서 거부 선택 시에도 Dialog가 열리는 이슈 수정
Geolocation API의 success 핸들러에서 Dialog 열도록 수정 

### 스크린샷
![image](https://github.com/user-attachments/assets/df660d26-244e-49dc-99c8-92598a2267e4)
