### PR TITLE
fix: Android에서 '정확한 위치 사용' 옵션 활성화 시 발생하는 geolocation 지연 문제 해결

### DIFF
--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -27,10 +27,35 @@ function DirectionWrap() {
     setIsError(false);
     setIsLoading(true);
 
+    console.log(`[디버깅] 위치 요청 시작 : ${new Date().toISOString}`);
+
     try {
       const position = await new Promise<GeolocationPosition>(
         (resolve, reject) => {
-          navigator.geolocation.getCurrentPosition(resolve, reject);
+          const startTime = performance.now();
+
+          navigator.geolocation.getCurrentPosition(
+            (position) => {
+              const endTime = performance.now();
+
+              console.log(
+                `[디버깅] 위치 요청 성공 - 소요 시간: ${endTime - startTime}ms`,
+              );
+              console.log('[디버깅] 위치 정보', {
+                latitude: position.coords.latitude,
+                longitude: position.coords.longitude,
+              });
+
+              resolve(position);
+            },
+            (error) => {
+              reject(error);
+            },
+            {
+              enableHighAccuracy: true,
+              maximumAge: 0,
+            },
+          );
         },
       );
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#43 

## 문제 상황
- Android에서 '정확한 위치 사용' 옵션이 활성화된 상태에서 `navigator.geolocation.getCurrentPosition` 호출 시 응답이 지연되는 문제가 발생함.
- 첫 번째 요청은 정상 동작하고 이후 두 번째 요청부터 지연이 심해지는 현상이 있음.

## 작업 내용
- `geolocation maximumAge: 0` 옵션을 추가하여 캐싱 된 위치를 사용하지 않도록 설정.
- 디버깅을 위해 `console.log` 추가하여 요청에 소요된 시간을 확인할 수 있도록 수정.

## 테스트 내용
- Android에서 '정확한 위치 사용' 옵션이 활성화 된 상태로 위치 요청 여러 번 시도해 지연 확인 
- Android에서 '정확한 위치 사용' 옵션이 활성화 된 상태와 비활성화 된 상태에서 위치 요청 시간 비교
