### PR TITLE
test: geolocation maxAge 옵션 제거

### DIFF
--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -53,7 +53,6 @@ function DirectionWrap() {
             },
             {
               enableHighAccuracy: true,
-              maximumAge: 0,
             },
           );
         },


### PR DESCRIPTION
## #️⃣연관된 이슈
#43 

## 📝작업 내용
- Geolocation maxAge 옵션 제거: Android(AOS) Geolocation 지연 이슈 원인 확인을 위해 
