### PR TITLE
Remove: Geolocation maxAge 옵션 제거

### DIFF
--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -53,7 +53,6 @@ function DirectionWrap() {
             },
             {
               enableHighAccuracy: true,
-              maximumAge: 0,
             },
           );
         },

--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -27,10 +27,35 @@ function DirectionWrap() {
     setIsError(false);
     setIsLoading(true);
 
+    console.log(`[디버깅] 위치 요청 시작 : ${new Date().toISOString}`);
+
     try {
       const position = await new Promise<GeolocationPosition>(
         (resolve, reject) => {
-          navigator.geolocation.getCurrentPosition(resolve, reject);
+          const startTime = performance.now();
+
+          navigator.geolocation.getCurrentPosition(
+            (position) => {
+              const endTime = performance.now();
+
+              console.log(
+                `[디버깅] 위치 요청 성공 - 소요 시간: ${endTime - startTime}ms`,
+              );
+              console.log('[디버깅] 위치 정보', {
+                latitude: position.coords.latitude,
+                longitude: position.coords.longitude,
+              });
+
+              resolve(position);
+            },
+            (error) => {
+              reject(error);
+            },
+            {
+              enableHighAccuracy: true,
+              maximumAge: 0,
+            },
+          );
         },
       );
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#43 

## 📝작업 내용
- Geolocation maxAge 옵션 제거: Android(AOS) Geolocation 지연 이슈 원인 확인을 위해 

