### PR TITLE
feat: 데이터 sessionStorage 캐싱 및 이미지 sizes 최적화로 성능 개선

### DIFF
--- a/app/components/common/LazyImage.tsx
+++ b/app/components/common/LazyImage.tsx
@@ -7,9 +7,10 @@ import SkeletonImage from '../Skeleton/SkeletonImage';
 interface LazyImageProps {
   thumbnail: string;
   alt: string;
+  sizes: string;
 }
 
-function LazyImage({ thumbnail, alt }: LazyImageProps) {
+function LazyImage({ thumbnail, alt, sizes }: LazyImageProps) {
   const [isLoading, setIsLoading] = useState(true);
 
   return (
@@ -19,7 +20,7 @@ function LazyImage({ thumbnail, alt }: LazyImageProps) {
         src={thumbnail}
         className="object-cover transition-transform duration-300 will-change-transform group-hover:scale-105"
         fill
-        sizes="(max-width: 768px) 50vw, 32vw"
+        sizes={sizes}
         alt={alt}
         onLoad={() => setIsLoading(false)}
       />

--- a/app/components/lists/Card.tsx
+++ b/app/components/lists/Card.tsx
@@ -22,7 +22,11 @@ function Card({ channel, lists }: CardInterface) {
           aria-label={`${title} 영상 보러가기`}
         >
           <div className="relative aspect-[1.75/1] w-full">
-            <LazyImage thumbnail={thumbnail} alt={`썸네일: ${title}`} />
+            <LazyImage
+              thumbnail={thumbnail}
+              alt={`썸네일: ${title}`}
+              sizes="(min-width: 780px) 237px, calc(48.48vw - 11px)"
+            />
           </div>
           <div className="h-full bg-card-background p-3 md:h-[5.5rem]">
             <Category keyValue={`${channel}_${position}`} category={category} />

--- a/app/components/video/VideoPlayer.tsx
+++ b/app/components/video/VideoPlayer.tsx
@@ -25,7 +25,11 @@ function VideoPlayer({ videoId, lazy, timeline, title }: VideoPlayerProps) {
   return (
     <>
       {!isLoaded && (
-        <LazyImage thumbnail={lazy} alt={`영상 썸네일: ${title}`} />
+        <LazyImage
+          thumbnail={lazy}
+          alt={`영상 썸네일: ${title}`}
+          sizes="(min-width: 780px) 716px, 95.65vw"
+        />
       )}
       {isClient && (
         <ReactPlayer


### PR DESCRIPTION
## 📝작업 내용
- sessionStorage에 channel 데이터 저장
- 반응형 이미지 사이즈 최적화 (Respimagelint)

### 스크린샷
#### sessionStorage에 channel 데이터 저장
![image](https://github.com/user-attachments/assets/db4fb456-0504-41d5-acef-6c477b123e43)
#### 반응형 이미지 사이즈 - 최적화 전
![image](https://github.com/user-attachments/assets/34d357e5-ab5a-401a-8897-51b5e06b6121)
#### 반응형 이미지 사이즈  - 최적화 후
![image](https://github.com/user-attachments/assets/0ae020a1-200c-4bb7-baeb-e1c2a87affce)

