### PR TITLE
feat: 채널별 데이터, 위치 데이터 zustand로 관리

### DIFF
--- a/app/components/Map/Map.tsx
+++ b/app/components/Map/Map.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import MapSkeleton from './MapSkeleton';
+import useDestinationStore from '@/app/stores/useDestinationStore';
 
 interface MapProps {
   address: string;
@@ -10,6 +11,9 @@ interface MapProps {
 function Map({ address }: MapProps) {
   const mapRef = useRef<naver.maps.Map | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const setDestinationData = useDestinationStore(
+    (state) => state.setDestinationData,
+  );
 
   const initMap = (lat: number, lng: number) => {
     const map = new naver.maps.Map('map', {
@@ -54,7 +58,7 @@ function Map({ address }: MapProps) {
         const lng = Number(result.x);
         const lat = Number(result.y);
 
-        sessionStorage.setItem('destination', `${lng},${lat}`);
+        setDestinationData({ longitude: lng, latitude: lat });
 
         initMap(lat, lng);
         setIsLoading(false);
@@ -66,7 +70,7 @@ function Map({ address }: MapProps) {
         mapRef.current.destroy();
       }
     };
-  }, [address]);
+  }, [address, setDestinationData]);
 
   return (
     <div className="relative h-[20rem] w-full overflow-hidden rounded-lg md:h-[25rem]">

--- a/app/components/direction/DirectionWrap.tsx
+++ b/app/components/direction/DirectionWrap.tsx
@@ -13,6 +13,7 @@ import DirectionDescription from './DirectionDescription';
 import IconRetry from '@/app/components/icons/IconRetry';
 import IconInfo from '@/app/components/icons/IconInfo';
 import handleGeolocationError from '@/app/utils/handleGeolocationError';
+import useDestinationStore from '@/app/stores/useDestinationStore';
 
 function DirectionWrap() {
   const { dialogRef, openDialog, closeDialog } = useDialog();
@@ -20,6 +21,7 @@ function DirectionWrap() {
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const destinationData = useDestinationStore((state) => state.destinationData);
 
   const requestCurrentLoaction = async () => {
     if (isLoading) return;
@@ -61,7 +63,7 @@ function DirectionWrap() {
     const latitude = position.coords.latitude;
     const longitude = position.coords.longitude;
     const start = `${longitude},${latitude}`;
-    const goal = sessionStorage.getItem('destination') || '';
+    const goal = `${destinationData?.longitude},${destinationData?.latitude}`;
 
     const { data, isError } = await getRoute(
       start,
@@ -107,7 +109,7 @@ function DirectionWrap() {
     <>
       <button
         type="button"
-        className="loading bg-btn-background my-2 flex h-11 w-full items-center justify-center gap-1 rounded-lg font-semibold"
+        className="loading my-2 flex h-11 w-full items-center justify-center gap-1 rounded-lg bg-btn-background font-semibold"
         onClick={handleFindRouteClick}
         aria-label="현재 위치에서 목적지까지 길 찾기"
         disabled={isLoading}

--- a/app/hooks/useFetchData.ts
+++ b/app/hooks/useFetchData.ts
@@ -10,8 +10,6 @@ const useFetchData = (
   initialHasNext: boolean,
   nextCursor: number | null,
 ) => {
-  // const { lists, cursors, hasNexts, setLists, setCursor, setHasNext } =
-  //   useListsStore();
   const {
     lists,
     cursors,

--- a/app/hooks/useFetchData.ts
+++ b/app/hooks/useFetchData.ts
@@ -10,8 +10,21 @@ const useFetchData = (
   initialHasNext: boolean,
   nextCursor: number | null,
 ) => {
-  const { lists, cursors, hasNexts, setLists, setCursor, setHasNext } =
-    useListsStore();
+  // const { lists, cursors, hasNexts, setLists, setCursor, setHasNext } =
+  //   useListsStore();
+  const {
+    lists,
+    cursors,
+    hasNexts,
+    setLists,
+    setCursor,
+    setHasNext,
+    initializeState,
+  } = useListsStore();
+
+  useEffect(() => {
+    initializeState();
+  }, [initializeState]);
 
   useEffect(() => {
     if (!lists[channel]) {
@@ -43,7 +56,7 @@ const useFetchData = (
       params: { limit: 12, cursor: cursors[channel] },
     });
 
-    setLists(channel, [...(lists[channel] || null), ...data.lists]);
+    setLists(channel, [...(lists[channel] || []), ...data.lists]);
     setCursor(channel, data.nextCursor);
     setHasNext(channel, data.hasNext);
   }, [channel, lists, cursors, hasNexts, setLists, setCursor, setHasNext]);

--- a/app/hooks/useFetchData.ts
+++ b/app/hooks/useFetchData.ts
@@ -25,14 +25,21 @@ const useFetchData = (
   }, [initializeState]);
 
   useEffect(() => {
-    if (!lists[channel]) {
-      setLists(channel, initialLists);
-    }
-    if (cursors[channel] === undefined) {
-      setCursor(channel, nextCursor);
-    }
-    if (hasNexts[channel] === undefined) {
-      setHasNext(channel, initialHasNext);
+    const sessionStorageData = sessionStorage.getItem('youtubeData');
+    const hasStoreData = sessionStorageData
+      ? JSON.parse(sessionStorageData)
+      : null;
+
+    if (!hasStoreData || !hasStoreData.lists[channel]) {
+      if (!lists[channel]) {
+        setLists(channel, initialLists);
+      }
+      if (cursors[channel] === undefined) {
+        setCursor(channel, nextCursor);
+      }
+      if (hasNexts[channel] === undefined) {
+        setHasNext(channel, initialHasNext);
+      }
     }
   }, [
     channel,

--- a/app/stores/useDestinationStore.ts
+++ b/app/stores/useDestinationStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+interface DestinationData {
+  latitude: number;
+  longitude: number;
+}
+
+interface DestinationStore {
+  destinationData: DestinationData | null;
+  setDestinationData: (data: DestinationData) => void;
+}
+
+const useDestinationStore = create<DestinationStore>((set) => ({
+  destinationData: null,
+  setDestinationData: (data) => set({ destinationData: data }),
+}));
+
+export default useDestinationStore;

--- a/app/stores/useListsStore.ts
+++ b/app/stores/useListsStore.ts
@@ -6,6 +6,7 @@ interface ListsStore {
   cursors: Record<string, number | null>;
   hasNexts: Record<string, boolean>;
 
+  initializeState: () => void;
   setLists: (channel: string, newLists: YoutubeData[]) => void;
   setCursor: (channel: string, cursor: number | null) => void;
   setHasNext: (channel: string, hasNext: boolean) => void;
@@ -16,20 +17,43 @@ const useListsStore = create<ListsStore>((set) => ({
   cursors: {},
   hasNexts: {},
 
+  initializeState: () => {
+    const sessionStorageData = sessionStorage.getItem('youtubeData');
+    if (sessionStorageData) {
+      const { lists, cursors, hasNexts } = JSON.parse(sessionStorageData);
+      set({ lists, cursors, hasNexts });
+    }
+  },
+
   setLists: (channel, newLists) =>
-    set((state) => ({
-      lists: { ...state.lists, [channel]: newLists },
-    })),
+    set((state) => {
+      const updatedLists = { ...state.lists, [channel]: newLists };
+      sessionStorage.setItem(
+        'youtubeData',
+        JSON.stringify({ ...state, lists: updatedLists }),
+      );
+      return { lists: updatedLists };
+    }),
 
   setCursor: (channel, cursor) =>
-    set((state) => ({
-      cursors: { ...state.cursors, [channel]: cursor },
-    })),
+    set((state) => {
+      const updatedCursors = { ...state.cursors, [channel]: cursor };
+      sessionStorage.setItem(
+        'youtubeData',
+        JSON.stringify({ ...state, cursor: updatedCursors }),
+      );
+      return { cursors: updatedCursors };
+    }),
 
   setHasNext: (channel, hasNext) =>
-    set((state) => ({
-      hasNexts: { ...state.hasNexts, [channel]: hasNext },
-    })),
+    set((state) => {
+      const updatedHasNexts = { ...state.hasNexts, [channel]: hasNext };
+      sessionStorage.setItem(
+        'youtubeData',
+        JSON.stringify({ ...state, hasNext: updatedHasNexts }),
+      );
+      return { hasNexts: updatedHasNexts };
+    }),
 }));
 
 export default useListsStore;

--- a/app/stores/useListsStore.ts
+++ b/app/stores/useListsStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { YoutubeData } from '@/app/types/youtube';
+
+interface ListsStore {
+  lists: Record<string, YoutubeData[]>;
+  cursors: Record<string, number | null>;
+  hasNexts: Record<string, boolean>;
+
+  setLists: (channel: string, newLists: YoutubeData[]) => void;
+  setCursor: (channel: string, cursor: number | null) => void;
+  setHasNext: (channel: string, hasNext: boolean) => void;
+}
+
+const useListsStore = create<ListsStore>((set) => ({
+  lists: {},
+  cursors: {},
+  hasNexts: {},
+
+  setLists: (channel, newLists) =>
+    set((state) => ({
+      lists: { ...state.lists, [channel]: newLists },
+    })),
+
+  setCursor: (channel, cursor) =>
+    set((state) => ({
+      cursors: { ...state.cursors, [channel]: cursor },
+    })),
+
+  setHasNext: (channel, hasNext) =>
+    set((state) => ({
+      hasNexts: { ...state.hasNexts, [channel]: hasNext },
+    })),
+}));
+
+export default useListsStore;

--- a/app/stores/useListsStore.ts
+++ b/app/stores/useListsStore.ts
@@ -40,7 +40,7 @@ const useListsStore = create<ListsStore>((set) => ({
       const updatedCursors = { ...state.cursors, [channel]: cursor };
       sessionStorage.setItem(
         'youtubeData',
-        JSON.stringify({ ...state, cursor: updatedCursors }),
+        JSON.stringify({ ...state, cursors: updatedCursors }),
       );
       return { cursors: updatedCursors };
     }),
@@ -50,7 +50,7 @@ const useListsStore = create<ListsStore>((set) => ({
       const updatedHasNexts = { ...state.hasNexts, [channel]: hasNext };
       sessionStorage.setItem(
         'youtubeData',
-        JSON.stringify({ ...state, hasNext: updatedHasNexts }),
+        JSON.stringify({ ...state, hasNexts: updatedHasNexts }),
       );
       return { hasNexts: updatedHasNexts };
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "prettier-plugin-tailwindcss": "^0.6.11",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-player": "^2.16.0"
+        "react-player": "^2.16.0",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -813,7 +814,7 @@
       "version": "19.0.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.7.tgz",
       "integrity": "sha512-MoFsEJKkAtZCrC1r6CM8U22GzhG7u2Wir8ons/aCKH6MBdD1ibV24zOSSkdZVUKqN5i396zG5VKLYZ3yaUZdLA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1665,7 +1666,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5968,6 +5969,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prettier-plugin-tailwindcss": "^0.6.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-player": "^2.16.0"
+    "react-player": "^2.16.0",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## 📝 작업 내용

- `zustand`를 사용하여 위치 정보(`longitude`, `latitude`)를 전역 상태로 관리
- 유튜브 채널 데이터를 `zustand`로 관리하며, 각 채널에 대한 데이터를 `sessionStorage`에 저장해 페이지 전환, 새로고침 시에도 데이터를 유지
- `zustand`와 `sessionStorage`를 결합하여 데이터를 효율적으로 관리하고, 불필요한 API 요청을 줄여 성능 개선
- 페이지 전환이나, 새로고침 시에도 데이터가 유지되어 UX 개선

## 👀 확인 사항
- 채널별 데이터가 정상적으로 불러와지고, 새로고침 후에도 유지되는지 확인.