### PR TITLE
feat: 메인 페이지 사이트맵 추가

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -56,6 +56,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   return [
     {
+      url: 'https://mat-gil.vercel.app',
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1.0,
+    },
+    {
       url: 'https://mat-gil.vercel.app/pungja',
       lastModified: new Date(),
       changeFrequency: 'daily',


### PR DESCRIPTION
## #️⃣연관된 이슈
#81 

## 📝작업 내용
- 메인 페이지 추가로 `sitemap`에 `https://mat-gil.vercel.app` 추가

