### PR TITLE
fix: remotePatterns의 hostname 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,9 +8,8 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname:
-          'sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Coworkers/user/1819/',
-        pathname: '/**',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Coworkers',
+        pathname: '/Coworkers/user/1819/**',
       },
     ],
   },


### PR DESCRIPTION
## #️⃣연관된 이슈

#90 
## 📝작업 내용
- next.config.ts에서 remotePatterns의 hostname에서 경로를 제거하여 올바른 도메인만 포함하도록 수정
