### PR TITLE
fix: remotePatterns의 hostname에서 일부 경로 제거 누락 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Coworkers',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
         pathname: '/Coworkers/user/1819/**',
       },
     ],


### PR DESCRIPTION
## #️⃣연관된 이슈
#90 

## 📝작업 내용
- next.config.ts에서 remotePatterns의 hostname에서 '/Coworkers' 경로 제거 누락 수정
