### PR TITLE
이미지 최적화

### DIFF
--- a/app/components/landing/RecommandedList.tsx
+++ b/app/components/landing/RecommandedList.tsx
@@ -7,6 +7,7 @@ import { useRef } from 'react';
 import { YoutubeData } from '@/app/types/youtube';
 import Category from '@/app/components/lists/Category';
 import IconMarker from '@/app/components/icons/IconMarker';
+import getImageServerUrlFromThumbnail from '@/app/utils/getImageServerUrlFromThumbnail';
 
 interface RecommandedProps {
   data: {
@@ -39,7 +40,7 @@ function RecommandedList({ data }: RecommandedProps) {
               >
                 <div className="relative h-36 w-full">
                   <LazyImage
-                    thumbnail={thumbnail}
+                    thumbnail={getImageServerUrlFromThumbnail(thumbnail)}
                     alt={`썸네일: ${title}`}
                     sizes="260px"
                   />

--- a/app/components/lists/Card.tsx
+++ b/app/components/lists/Card.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import IconMarker from '@/app/components/icons/IconMarker';
 import Category from './Category';
 import LazyImage from '@/app/components/common/LazyImage';
+import getImageServerUrlFromThumbnail from '@/app/utils/getImageServerUrlFromThumbnail';
 interface CardInterface {
   channel: string;
   lists: YoutubeData[];
@@ -22,7 +23,7 @@ function Card({ channel, lists }: CardInterface) {
         >
           <div className="relative aspect-[1.75/1] w-full">
             <LazyImage
-              thumbnail={thumbnail}
+              thumbnail={getImageServerUrlFromThumbnail(thumbnail)}
               alt={`썸네일: ${title}`}
               sizes="(min-width: 780px) 237px, calc(48.48vw - 11px)"
             />

--- a/app/components/video/VideoPlayer.tsx
+++ b/app/components/video/VideoPlayer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import ReactPlayer from 'react-player/lazy';
 import convertTimeToSeconds from '@/app/utils/convertTimeToSeconds';
 import LazyImage from '@/app/components/common/LazyImage';
+import getImageServerUrlFromThumbnail from '@/app/utils/getImageServerUrlFromThumbnail';
 interface VideoPlayerProps {
   videoId: string;
   lazy: string;
@@ -25,7 +26,7 @@ function VideoPlayer({ videoId, lazy, timeline, title }: VideoPlayerProps) {
     <>
       {!isLoaded && (
         <LazyImage
-          thumbnail={lazy}
+          thumbnail={getImageServerUrlFromThumbnail(lazy)}
           alt={`영상 썸네일: ${title}`}
           sizes="(min-width: 780px) 716px, 95.65vw"
         />

--- a/app/utils/getImageServerUrlFromThumbnail.ts
+++ b/app/utils/getImageServerUrlFromThumbnail.ts
@@ -1,0 +1,8 @@
+const getImageServerUrlFromThumbnail = (thumbnailUrl: string) => {
+  return thumbnailUrl
+    .replace('i.ytimg.com/vi/', 'optimized-images-mat-gil.netlify.app/images/')
+    .replace('/hqdefault.jpg', '')
+    .concat('.webp');
+};
+
+export default getImageServerUrlFromThumbnail;

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'i.ytimg.com',
+        hostname: 'optimized-images-mat-gil.netlify.app',
         pathname: '/**',
       },
     ],


### PR DESCRIPTION
## #️⃣연관된 이슈

#90 

## 📝작업 내용
- JSON 데이터의 `thumbnail URL`을 `Netlify 이미지 서버 URL` 로 변환하는 유틸 함수 `getImageServerUrlFromThumbnail` 추가
- Youtube Thumbail을 사용하던 페이지에 `getImageServerUrlFromThumbnail` 유틸을 적용해 이미지 서버에서 최적화된 이미지를 받아오도록 수정
- `next.config.ts`의 `remotePattern hostname` 옵션을 이미지 서버 도메인으로 수정
### 결과
![image](https://github.com/user-attachments/assets/007257dd-61f2-4d4a-b89d-fae82a12bffb)
![image](https://github.com/user-attachments/assets/1f285db0-c7c6-42cd-a8ff-db2b86a6f5f4)

