### PR TITLE
fix: SSR 데이터 렌더링 문제 해결

### DIFF
--- a/app/[channel]/page.tsx
+++ b/app/[channel]/page.tsx
@@ -3,6 +3,7 @@ import ListContainer from '@/app/components/lists/ListContainer';
 import { Metadata } from 'next';
 import channelMap from '@/app/constants/channelMap';
 import ListSchema from '@/app/components/seo/ListSchema';
+import Card from '@/app/components/lists/Card';
 
 export async function generateMetadata({
   params,
@@ -57,12 +58,18 @@ async function ChannelHome({
   return (
     <>
       <ListSchema channel={channel} lists={lists} />
-      <ListContainer
-        channel={channel}
-        hasNext={hasNext}
-        nextCursor={nextCursor}
-        lists={lists}
-      />
+      <ul
+        className="mx-auto flex flex-wrap gap-x-[3%] gap-y-4 px-3 py-5 md:w-[46.25rem] md:gap-x-[2%] md:gap-y-5 md:px-0"
+        role="list"
+        aria-label="맛집 목록"
+      >
+        <Card channel={channel} lists={lists} />
+        <ListContainer
+          channel={channel}
+          hasNext={hasNext}
+          nextCursor={nextCursor}
+        />
+      </ul>
     </>
   );
 }

--- a/app/components/lists/ListContainer.tsx
+++ b/app/components/lists/ListContainer.tsx
@@ -1,24 +1,20 @@
 'use client';
 
-import { YoutubeData } from '@/app/types/youtube';
 import Card from './Card';
 import useFetchData from '@/app/hooks/useFetchData';
 import { useEffect } from 'react';
 
 function ListContainer({
-  lists: initialLists,
   channel,
   hasNext: initialHasNext,
   nextCursor,
 }: {
-  lists: YoutubeData[];
   channel: string;
   hasNext: boolean;
   nextCursor: number | null;
 }) {
   const { lists, hasNext, endRef } = useFetchData(
     channel,
-    initialLists,
     initialHasNext,
     nextCursor,
   );
@@ -28,14 +24,10 @@ function ListContainer({
   }, [channel]);
 
   return (
-    <ul
-      className="mx-auto flex flex-wrap gap-x-[3%] gap-y-4 px-3 py-5 md:w-[46.25rem] md:gap-x-[2%] md:gap-y-5 md:px-0"
-      role="list"
-      aria-label="맛집 목록"
-    >
+    <>
       <Card channel={channel} lists={lists} />
       {hasNext && <div ref={endRef} className="h-0.5 w-full" />}
-    </ul>
+    </>
   );
 }
 

--- a/app/hooks/useFetchData.ts
+++ b/app/hooks/useFetchData.ts
@@ -1,12 +1,11 @@
 import { useCallback, useEffect } from 'react';
-import { ChannelResponse, YoutubeData } from '../types/youtube';
+import { ChannelResponse } from '@/app/types/youtube';
 import axios from '@/app/lib/instance';
 import useIntersectionObserver from '@/app/hooks/useIntersectionObserver';
 import useListsStore from '@/app/stores/useListsStore';
 
 const useFetchData = (
   channel: string,
-  initialLists: YoutubeData[],
   initialHasNext: boolean,
   nextCursor: number | null,
 ) => {
@@ -32,7 +31,7 @@ const useFetchData = (
 
     if (!hasStoreData || !hasStoreData.lists[channel]) {
       if (!lists[channel]) {
-        setLists(channel, initialLists);
+        setLists(channel, []);
       }
       if (cursors[channel] === undefined) {
         setCursor(channel, nextCursor);
@@ -43,7 +42,6 @@ const useFetchData = (
     }
   }, [
     channel,
-    initialLists,
     initialHasNext,
     nextCursor,
     lists,


### PR DESCRIPTION
## #️⃣연관된 이슈
#101 

## 📝작업 내용
- 채널 페이지(`/[channel]`)에서 `SSR(Server-Side Rendering)`을 통해 초기 데이터를 렌더링하도록 수정
- `ListContainer` 컴포넌트의 구조를 개선하여 서버와 클라이언트 렌더링을 분리
- 서버에서 응답 받은 초기 `HTML`에 맛집 리스트 데이터 포함을 보장하여 성능 및 SEO 개선

### 스크린샷 (선택)
- 서버 컴포넌트 수정 전 - 클라이언트 컴포넌트에 서버 데이터를 넘겨 렌더링
![image](https://github.com/user-attachments/assets/b5027bbb-09f9-454f-9020-4c29b5543ad6)
- 서버 컴포넌트 수정 후 - 서버 컴포넌트에서 데이터를 렌더링
![image](https://github.com/user-attachments/assets/7bca4a47-e784-4de3-a2cb-f61d0edb57f1)
